### PR TITLE
Annual flow

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -2,7 +2,7 @@
 
 Project overview
 - Streamwise is a Kotlin Multiplatform project focused on modeling and visualizing cash flows (e.g., Fixed, Weekly, Monthly) and exposing them to a web UI.
-- Technologies: Kotlin Multiplatform (shared logic), Kotlin/JS for web, TypeScript interop, Angular in TypeScript, Gradle build, Kotlinx Serialization and DateTime, ION‑Spin BigNum, optional Firebase emulation for local development.
+- Technologies: Kotlin Multiplatform (shared logic), Firebase (server), Kotlin/JS for web, TypeScript interop, Angular in TypeScript, Gradle build, Kotlinx Serialization and DateTime, ION‑Spin BigNum, optional Firebase emulation for local development.
 
 Repository structure
 - shared: Multiplatform library with core domain types and logic.
@@ -26,11 +26,22 @@ Testing guidance for Junie
 - When modifying webApp Kotlin/JS interop or TS usage impacting compilation, run: ./gradlew :webApp:buildWebApp
 - Prefer running the narrowest set of tasks necessary to validate changes; fall back to ./gradlew build if unsure.
 
+Data model
+- The application uses Firestore to store application data.
+- Security rules keep user data private.
+- Cash flow bundles' flows reference the cash flow owner for access control.
+
 Coding conventions
 - Kotlin: Follow idiomatic Kotlin style; prefer immutable data structures and pure functions for domain logic.
 - Serialization: Use kotlinx.serialization annotations already present; keep types stable across JS interop (avoid non-exportable types in @JsExport APIs).
 - Numeric types: Monetary values use ION‑Spin BigDecimal; avoid Double for money.
 - Tests: Add or update tests under shared/src/commonTest for domain changes.
+
+What is a cash flow?
+- A cash flow represents some amount of money on some date.
+- Types of cash flows include Fixed (one-time), Weekly, Monthly, etc.
+- The Firebase data model organizes cash flows into *bundles*.
+- A bundle has a subcollection for each type of cash flow.
 
 What Junie should do when handling issues
 - Make minimal changes required to satisfy the issue.

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,6 +33,11 @@ service cloud.firestore {
         // Allow reads by owner
         allow read, write: if get(/databases/(default)/documents/flowBundles/$(bundleId)).data.ownerUid == request.auth.uid;
       }
+
+      match /yearlyFlows/{yearlyFlowId} {
+        // Allow reads by owner
+        allow read, write: if get(/databases/(default)/documents/flowBundles/$(bundleId)).data.ownerUid == request.auth.uid;
+      }
     }
     match /{document=**} {
       allow read, write: if isAdmin();

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Yearly.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Yearly.kt
@@ -1,0 +1,61 @@
+package io.rwc.streamwise.flows
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import com.ionspin.kotlin.bignum.serialization.kotlinx.bigdecimal.BigDecimalHumanReadableSerializer
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.Serializable
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+
+/**
+ * A cash flow that occurs on a yearly cadence, on the anniversary of the start date.
+ *
+ * The occurrence interval is (skip + 1) years.
+ * - skip = 0 → every year
+ * - skip = 1 → every 2 years
+ * - skip = 2 → every 3 years
+ */
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@Serializable
+data class Yearly(
+  val name: String,
+  val startDate: LocalDate,
+  @Serializable(with = BigDecimalHumanReadableSerializer::class)
+  val amount: BigDecimal,
+  val skip: Int = 0,
+) : CashFlow {
+  init {
+    require(skip >= 0) { "Skip cannot be negative" }
+  }
+
+  override fun valueOn(date: LocalDate): BigDecimal {
+    if (date < startDate) return BigDecimal.ZERO
+
+    val intervalYears = skip + 1
+    val yearsFromStart = date.year - startDate.year
+    if (yearsFromStart % intervalYears != 0) return BigDecimal.ZERO
+
+    val anniversary = anniversaryInYear(date.year)
+    return if (date == anniversary) amount else BigDecimal.ZERO
+  }
+
+  private fun anniversaryInYear(year: Int): LocalDate {
+    return if (startDate.monthNumber == 2 && startDate.dayOfMonth == 29) {
+      // For Feb 29 starts, use Feb 29 on leap years, otherwise Feb 28
+      if (isLeapYear(year)) LocalDate(year, 2, 29) else LocalDate(year, 2, 28)
+    } else {
+      LocalDate(year, startDate.monthNumber, startDate.dayOfMonth)
+    }
+  }
+
+  private fun isLeapYear(year: Int): Boolean {
+    // Constructing Feb 29 will throw on non-leap years; catch to determine
+    return try {
+      LocalDate(year, 2, 29)
+      true
+    } catch (e: IllegalArgumentException) {
+      false
+    }
+  }
+}

--- a/shared/src/commonTest/kotlin/io/rwc/streamwise/flows/YearlyTest.kt
+++ b/shared/src/commonTest/kotlin/io/rwc/streamwise/flows/YearlyTest.kt
@@ -1,0 +1,76 @@
+package io.rwc.streamwise.flows
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class YearlyTest {
+
+  @Test
+  fun `occurs on start date and every year thereafter when skip is 0`() {
+    val amount = BigDecimal.fromInt(100)
+    val yearly = Yearly(name = "membership", startDate = LocalDate(2020, 5, 10), amount = amount, skip = 0)
+
+    // On start date
+    assertEquals(amount, yearly.valueOn(LocalDate(2020, 5, 10)))
+
+    // Next years same day
+    assertEquals(amount, yearly.valueOn(LocalDate(2021, 5, 10)))
+    assertEquals(amount, yearly.valueOn(LocalDate(2022, 5, 10)))
+
+    // Not on an occurrence
+    assertEquals(BigDecimal.ZERO, yearly.valueOn(LocalDate(2021, 5, 11)))
+  }
+
+  @Test
+  fun `occurs every 2 years when skip is 1`() {
+    val amount = BigDecimal.fromInt(250)
+    val yearly = Yearly(name = "biennial", startDate = LocalDate(2020, 3, 1), amount = amount, skip = 1)
+
+    // Start year
+    assertEquals(amount, yearly.valueOn(LocalDate(2020, 3, 1)))
+
+    // Next year should not occur
+    assertEquals(BigDecimal.ZERO, yearly.valueOn(LocalDate(2021, 3, 1)))
+
+    // Two years later should occur
+    assertEquals(amount, yearly.valueOn(LocalDate(2022, 3, 1)))
+  }
+
+  @Test
+  fun `dates before start date do not produce value`() {
+    val amount = BigDecimal.fromInt(20)
+    val yearly = Yearly(name = "annual", startDate = LocalDate(2023, 5, 15), amount = amount)
+
+    assertEquals(BigDecimal.ZERO, yearly.valueOn(LocalDate(2023, 5, 14)))
+    assertEquals(amount, yearly.valueOn(LocalDate(2023, 5, 15)))
+  }
+
+  @Test
+  fun `negative skip throws`() {
+    assertFailsWith<IllegalArgumentException> {
+      Yearly(name = "bad", startDate = LocalDate(2023, 1, 1), amount = BigDecimal.fromInt(1), skip = -1)
+    }
+  }
+
+  @Test
+  fun `feb 29 start occurs feb 28 on non-leap years`() {
+    val amount = BigDecimal.fromInt(75)
+    val yearly = Yearly(name = "leap", startDate = LocalDate(2020, 2, 29), amount = amount)
+
+    // Leap year start
+    assertEquals(amount, yearly.valueOn(LocalDate(2020, 2, 29)))
+
+    // Non-leap year should occur on Feb 28
+    assertEquals(amount, yearly.valueOn(LocalDate(2021, 2, 28)))
+
+    // Not on Feb 27 or Mar 1
+    assertEquals(BigDecimal.ZERO, yearly.valueOn(LocalDate(2021, 2, 27)))
+    assertEquals(BigDecimal.ZERO, yearly.valueOn(LocalDate(2021, 3, 1)))
+
+    // Next leap year occurrence
+    assertEquals(amount, yearly.valueOn(LocalDate(2024, 2, 29)))
+  }
+}

--- a/webApp/src/jsMain/kotlin/io/rwc/streamwise/FlowBundleService.kt
+++ b/webApp/src/jsMain/kotlin/io/rwc/streamwise/FlowBundleService.kt
@@ -21,6 +21,7 @@ class FlowBundleService {
       bundles.readCashFlows("fixedFlows", Fixed.serializer()),
       bundles.readCashFlows("monthlyFlows", Monthly.serializer()),
       bundles.readCashFlows("weeklyFlows", Weekly.serializer()),
+      bundles.readCashFlows("yearlyFlows", Yearly.serializer()),
     )
     val bundleFlows = combine(subCollectionFlows) { flowLists -> flowLists.flatMap { it } }
 
@@ -43,6 +44,7 @@ class FlowBundleService {
       bundles.readCashFlows("fixedFlows", Fixed.serializer()),
       bundles.readCashFlows("monthlyFlows", Monthly.serializer()),
       bundles.readCashFlows("weeklyFlows", Weekly.serializer()),
+      bundles.readCashFlows("yearlyFlows", Yearly.serializer()),
     )
     val allFlows = combine(subCollectionFlows) { flowLists -> flowLists.flatMap { it } }
 


### PR DESCRIPTION
Add an annual flow that occurs on a date, and repeating annually thereafter (potentially skipping years).

Also improve Junie guidelines.

Fixes #23 