### PR TITLE
Fix descriptions

### DIFF
--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/CashFlow.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/CashFlow.kt
@@ -6,7 +6,7 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
 
-interface CashFlow {
+sealed interface CashFlow {
   fun valueOn(date: LocalDate): BigDecimal
 }
 

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Descriptions.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Descriptions.kt
@@ -1,0 +1,14 @@
+package io.rwc.streamwise.flows
+
+/**
+ * Shared description for CashFlow types used by the UI.
+ *
+ * Throws IllegalArgumentException if the flow type is not recognized so callers
+ * can handle and display a generic error message.
+ */
+fun CashFlow.describe(): String = when (this) {
+  is Fixed -> "Fixed on ${this.date}: ${this.amount}"
+  is Monthly -> "Monthly ${this.name} on day offset ${this.dayOffset}: ${this.amount}"
+  is Weekly -> "Weekly ${this.name} starting ${this.startDate} (every ${this.skip + 1} week${if (this.skip == 0) "" else "s"}): ${this.amount}"
+  is Yearly -> "Yearly ${this.name} starting ${this.startDate} (every ${this.skip + 1} year${if (this.skip == 0) "" else "s"}): ${this.amount}"
+}

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Weekly.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Weekly.kt
@@ -16,8 +16,6 @@ import kotlin.js.JsExport
  * - skip = 1 → every 2 weeks
  * - skip = 2 → every 3 weeks
  */
-@OptIn(ExperimentalJsExport::class)
-@JsExport
 @Serializable
 data class Weekly(
   val name: String,

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Yearly.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Yearly.kt
@@ -16,8 +16,6 @@ import kotlin.js.JsExport
  * - skip = 1 → every 2 years
  * - skip = 2 → every 3 years
  */
-@OptIn(ExperimentalJsExport::class)
-@JsExport
 @Serializable
 data class Yearly(
   val name: String,

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Yearly.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Yearly.kt
@@ -3,6 +3,7 @@ package io.rwc.streamwise.flows
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.serialization.kotlinx.bigdecimal.BigDecimalHumanReadableSerializer
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 import kotlinx.serialization.Serializable
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
@@ -41,11 +42,11 @@ data class Yearly(
   }
 
   private fun anniversaryInYear(year: Int): LocalDate {
-    return if (startDate.monthNumber == 2 && startDate.dayOfMonth == 29) {
+    return if (startDate.month.number == 2 && startDate.day == 29) {
       // For Feb 29 starts, use Feb 29 on leap years, otherwise Feb 28
       if (isLeapYear(year)) LocalDate(year, 2, 29) else LocalDate(year, 2, 28)
     } else {
-      LocalDate(year, startDate.monthNumber, startDate.dayOfMonth)
+      LocalDate(year, startDate.month.number, startDate.day)
     }
   }
 

--- a/webApp/src/jsMain/kotlin/io/rwc/streamwise/FlowListComponent.kt
+++ b/webApp/src/jsMain/kotlin/io/rwc/streamwise/FlowListComponent.kt
@@ -2,6 +2,7 @@ package io.rwc.streamwise
 
 import io.rwc.streamwise.flows.CashFlow
 import io.rwc.streamwise.flows.FlowBundle
+import io.rwc.streamwise.flows.describe
 import kangular.core.AngularWritable
 
 @OptIn(ExperimentalJsExport::class)
@@ -17,10 +18,10 @@ class FlowListComponent(ngFlowsSignal: dynamic) {
 
   @Suppress("unused", "non_exportable_type")
   fun describe(flow: CashFlow): String {
-    return when (flow) {
-      is io.rwc.streamwise.flows.Fixed -> "Fixed on ${flow.date}: ${flow.amount}"
-      is io.rwc.streamwise.flows.Monthly -> "Monthly ${flow.name} on day offset ${flow.dayOffset}: ${flow.amount}"
-      else -> "Unknown flow type"
+    return try {
+      flow.describe()
+    } catch (e: Exception) {
+      "Unknown flow type"
     }
   }
 


### PR DESCRIPTION
Addresses some AI coding issues: (+ my failing to notice)

* Descriptions: the weekly + yearly cash flows didn't have descriptions 
* JsExport: we actually aren't exporting cash flows to JS for now … the localdate + bigdecimal types aren't exportable …

Fixes #28